### PR TITLE
Add has_solutions metadata

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -119,5 +119,8 @@
   ],
   "title": "Country, Regional and World GDP (Gross Domestic Product)",
   "version": "2026",
-  "collection": "economic-data"
+  "collection": "economic-data",
+  "has_solutions": [
+    "global-country-region-reference-data"
+  ]
 }


### PR DESCRIPTION
Adds `has_solutions` metadata in `datapackage.json` indicating which DataHub Solution package(s) this dataset belongs to:

- global-country-region-reference-data